### PR TITLE
Add QR favicon

### DIFF
--- a/app/static/favicon.svg
+++ b/app/static/favicon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">QRCode favicon</title>
+  <desc id="desc">Stylized QR code icon with three finder squares and pixel modules.</desc>
+  <rect width="64" height="64" rx="12" fill="#0f172a"/>
+  <rect x="8" y="8" width="18" height="18" rx="3" fill="#ffffff"/>
+  <rect x="12" y="12" width="10" height="10" rx="2" fill="#0f172a"/>
+  <rect x="38" y="8" width="18" height="18" rx="3" fill="#ffffff"/>
+  <rect x="42" y="12" width="10" height="10" rx="2" fill="#0f172a"/>
+  <rect x="8" y="38" width="18" height="18" rx="3" fill="#ffffff"/>
+  <rect x="12" y="42" width="10" height="10" rx="2" fill="#0f172a"/>
+  <rect x="34" y="34" width="6" height="6" rx="1.5" fill="#22c55e"/>
+  <rect x="42" y="34" width="6" height="6" rx="1.5" fill="#ffffff"/>
+  <rect x="50" y="34" width="6" height="6" rx="1.5" fill="#22c55e"/>
+  <rect x="34" y="42" width="6" height="6" rx="1.5" fill="#ffffff"/>
+  <rect x="42" y="42" width="6" height="6" rx="1.5" fill="#22c55e"/>
+  <rect x="50" y="42" width="6" height="6" rx="1.5" fill="#ffffff"/>
+  <rect x="34" y="50" width="6" height="6" rx="1.5" fill="#22c55e"/>
+  <rect x="42" y="50" width="6" height="6" rx="1.5" fill="#ffffff"/>
+  <rect x="50" y="50" width="6" height="6" rx="1.5" fill="#22c55e"/>
+</svg>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <title>Home - QRCode Generator</title>
     <meta name="description" content="Simple QRCode generator!">
+    <link rel="icon" href="/favicon.svg?v=1" type="image/svg+xml">
+    <link rel="shortcut icon" href="/favicon.svg?v=1" type="image/svg+xml">
     <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato" crossorigin="anonymous">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Catamaran:100,200,300,400,500,600,700,800,900" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
- add a QR-style SVG favicon
- wire the favicon into the main template
- keep the app branding aligned with the QRCode product

## Validation
- verified review deployment on foxhound serves `/favicon.svg?v=1`
- verified the homepage references the favicon asset
